### PR TITLE
Fixed tangle setting for mac-key mode

### DIFF
--- a/kjhealy.org
+++ b/kjhealy.org
@@ -144,7 +144,7 @@ When your frame (i.e., the main Emacs window) is split into different parts (e.g
     Used with Mitsuharu Yamamoto's carbon-patched Emacs, which turns
     off support for default mac bindings. Turned off by default.
 #+srcname: mac-keys
-#+begin_src emacs-lisp tangle: no
+#+begin_src emacs-lisp :tangle no
    (setq mac-command-modifier 'alt mac-option-modifier 'meta)
    (require 'redo+)
    (require 'mac-key-mode)


### PR DESCRIPTION
The documentation for the mac-key-mode source block says that it is turned off by default, but the tangle option was set incorrectly, resulting in mac-key-mode being enabled by default. This commit fixes this issue.
